### PR TITLE
Escaped logical or in table of logical operators.

### DIFF
--- a/content/decisions-with-conditionals/reading/logical-operators/_index.md
+++ b/content/decisions-with-conditionals/reading/logical-operators/_index.md
@@ -174,7 +174,7 @@ The following table lists operators in order of precedence, from highest (applie
 |            | Comparison                    | `<=`, `>=`, `>`, `<`     |
 |            | Equality                      | `===`, `!==`, `==`, `!=` |
 |            | Logical AND                   | `&&`                     |
-| (lowest)   | Logical OR                    | `||`                     |
+| (lowest)   | Logical OR                    | `\|\|`                     |
 
 
 ## Truth Tables


### PR DESCRIPTION
Just needed to escape pipes or they get picked up as table cell separators in markdown.